### PR TITLE
fix:自定义meterProvider

### DIFF
--- a/src/OpenTelemetryServiceProvider.php
+++ b/src/OpenTelemetryServiceProvider.php
@@ -68,9 +68,10 @@ class OpenTelemetryServiceProvider extends ServiceProvider
         // register custom meter
         $this->app->singleton(MeterInterface::class, function () {
             $resourceInfo = (new Sdk)->getResource();
-            Metric::$meterProvider = (new MeterProviderFactory)->create($resourceInfo);
+            $meterProvider = (new MeterProviderFactory)->create($resourceInfo);
+            Metric::setProvider($meterProvider);
 
-            return Metric::$meterProvider->getMeter(config('otel.meter_name', 'overtrue.laravel-open-telemetry'));
+            return $meterProvider->getMeter(config('otel.meter_name', 'overtrue.laravel-open-telemetry'));
         });
 
         $this->app->alias(MeterInterface::class, 'opentelemetry.meter');

--- a/src/OpenTelemetryServiceProvider.php
+++ b/src/OpenTelemetryServiceProvider.php
@@ -12,10 +12,13 @@ use Laravel\Octane\Events;
 use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Metrics\MeterInterface;
 use OpenTelemetry\API\Trace\TracerInterface;
+use OpenTelemetry\SDK\Metrics\MeterProviderFactory;
+use OpenTelemetry\SDK\Resource\Detectors\Sdk;
 use Overtrue\LaravelOpenTelemetry\Console\Commands\TestCommand;
 use Overtrue\LaravelOpenTelemetry\Facades\Measure;
 use Overtrue\LaravelOpenTelemetry\Http\Middleware\AddTraceId;
 use Overtrue\LaravelOpenTelemetry\Http\Middleware\TraceRequest;
+use Overtrue\LaravelOpenTelemetry\Support\Metric;
 
 class OpenTelemetryServiceProvider extends ServiceProvider
 {
@@ -62,9 +65,12 @@ class OpenTelemetryServiceProvider extends ServiceProvider
         });
         $this->app->alias(Support\Metric::class, 'opentelemetry.metric');
 
+        // register custom meter
         $this->app->singleton(MeterInterface::class, function () {
-            return Globals::meterProvider()
-                ->getMeter(config('otel.meter_name', 'overtrue.laravel-open-telemetry'));
+            $resourceInfo = (new Sdk)->getResource();
+            Metric::$meterProvider = (new MeterProviderFactory)->create($resourceInfo);
+
+            return Metric::$meterProvider->getMeter(config('otel.meter_name', 'overtrue.laravel-open-telemetry'));
         });
 
         $this->app->alias(MeterInterface::class, 'opentelemetry.meter');

--- a/src/Support/Metric.php
+++ b/src/Support/Metric.php
@@ -4,11 +4,11 @@ namespace Overtrue\LaravelOpenTelemetry\Support;
 
 use Illuminate\Contracts\Foundation\Application;
 use Illuminate\Support\Facades\Log;
-use OpenTelemetry\API\Globals;
 use OpenTelemetry\API\Metrics\CounterInterface;
 use OpenTelemetry\API\Metrics\GaugeInterface;
 use OpenTelemetry\API\Metrics\HistogramInterface;
 use OpenTelemetry\API\Metrics\MeterInterface;
+use OpenTelemetry\API\Metrics\MeterProviderInterface;
 use OpenTelemetry\API\Metrics\Noop\NoopMeter;
 use OpenTelemetry\API\Metrics\ObservableGaugeInterface;
 use Throwable;
@@ -16,6 +16,8 @@ use Throwable;
 class Metric
 {
     private static ?bool $enabled = null;
+
+    public static ?MeterProviderInterface $meterProvider = null;
 
     public function __construct(protected Application $app) {}
 
@@ -45,7 +47,7 @@ class Metric
      */
     public function flush(): void
     {
-        Globals::meterProvider()?->forceFlush();
+        self::$meterProvider?->forceFlush();
     }
 
     // ======================= Core OpenTelemetry API =======================

--- a/src/Support/Metric.php
+++ b/src/Support/Metric.php
@@ -17,7 +17,7 @@ class Metric
 {
     private static ?bool $enabled = null;
 
-    public static ?MeterProviderInterface $meterProvider = null;
+    private static ?MeterProviderInterface $meterProvider = null;
 
     public function __construct(protected Application $app) {}
 
@@ -48,6 +48,16 @@ class Metric
     public function flush(): void
     {
         self::$meterProvider?->forceFlush();
+    }
+
+    public static function getProvider(): MeterProviderInterface
+    {
+        return self::$meterProvider;
+    }
+
+    public static function setProvider(MeterProviderInterface $meterProvider): void
+    {
+        self::$meterProvider = $meterProvider;
     }
 
     // ======================= Core OpenTelemetry API =======================


### PR DESCRIPTION
自定义meterProvider，因为默认的provider中会携带service.instance.id属性，上报到prometheus的时候会自动转换为instance属性，为了避免instance属性被覆盖，所以使用自定义的meterProvider